### PR TITLE
Load swaggerUi before adding api_key authorization (issue #22)

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -108,14 +108,14 @@ if (app()->environment() != 'testing') {
                 addApiKeyAuthorization();
             });
 
+            window.swaggerUi.load();
+            
             // if you have an apiKey you would like to pre-populate on the page for demonstration purposes
             // just put it in the .env file, API_AUTH_TOKEN variable
             @if($apiKey)
             $('#input_apiKey').val("{{$apiKey}}");
             addApiKeyAuthorization();
             @endif
-
-            window.swaggerUi.load();
         });
     </script>
 </head>


### PR DESCRIPTION
window.swaggerUi.api is null if not loaded before addApiKeyAuthorization() called

issue #22
